### PR TITLE
Fix: Only start dev server and file watcher when not in production (#44)

### DIFF
--- a/packages/pattern-lab/index.js
+++ b/packages/pattern-lab/index.js
@@ -24,6 +24,8 @@ const runPatternlabGenerator = debounce(() => {
 });
 
 module.exports = (neutrino, options = {}) => {
+  const isProduction = process.env.NODE_ENV === "production";
+
   const defaults = {
     devServer: {
       contentBase: path.resolve("public"),
@@ -49,18 +51,23 @@ module.exports = (neutrino, options = {}) => {
     ...options
   };
 
-  neutrino.use(devServer, pluginOptions.devServer);
+  // Start dev server and file watcher only when not in production
+  if (!isProduction) {
+    neutrino.use(devServer, pluginOptions.devServer);
 
-  neutrino.config
-    .plugin("WriteFilePlugin")
-    .use(new WriteFilePlugin(pluginOptions.writeFileOptions));
+    neutrino.config.plugin("FilewatcherPlugin").use(
+      new FilewatcherPlugin({
+        watchFileRegex: pluginOptions.filWatcherOptions.watchFileRegex,
+        onReadyCallback: runPatternlabGenerator,
+        onChangeCallback: runPatternlabGenerator,
+        ignored: pluginOptions.filWatcherOptions.ignored
+      })
+    );
 
-  neutrino.config.plugin("FilewatcherPlugin").use(
-    new FilewatcherPlugin({
-      watchFileRegex: pluginOptions.filWatcherOptions.watchFileRegex,
-      onReadyCallback: runPatternlabGenerator,
-      onChangeCallback: runPatternlabGenerator,
-      ignored: pluginOptions.filWatcherOptions.ignored
-    })
-  );
+    neutrino.config
+      .plugin("WriteFilePlugin")
+      .use(new WriteFilePlugin(pluginOptions.writeFileOptions));
+  } else {
+    runPatternlabGenerator();
+  }
 };

--- a/packages/pattern-lab/index.js
+++ b/packages/pattern-lab/index.js
@@ -67,7 +67,5 @@ module.exports = (neutrino, options = {}) => {
     neutrino.config
       .plugin("WriteFilePlugin")
       .use(new WriteFilePlugin(pluginOptions.writeFileOptions));
-  } else {
-    runPatternlabGenerator();
   }
 };


### PR DESCRIPTION
Only starts web dev server when not in prod. 

This allows running `yarn run build` and the process will exit as expected. 

Build order might *still* be wrong (e.g. PL gets build to public before css and js have been build)

I'm running `exec` pretty naive here. 

Please review and verify that this is working. 

If you want to test this locally run `yarn link` in the pattern lab package after checking out the branch. 