### PR TITLE
Add an option to core for not modifying the font file names

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -150,7 +150,9 @@ module.exports = (neutrino, opts = {}) => {
       ]
     })
     .use(images)
-    .use(fonts);
+    .use(fonts, {
+      name: "[name].[ext]",
+    });
 
   neutrino.config
     .when(isProduction, () => neutrino.use(minify))


### PR DESCRIPTION
By default, hash is added to font file names when creating a production build.
We should have an option to disable that because
- this makes preloading the fonts impossible (as we do not know the file name in the templates)
- font files usually never change, so there is no need to add a hash. If they do change, we should rename them manually as that's a more unlikely case.

I did not want to make this the default behavior for now to not break anything (although I don't think it would), but if you're open for that, I would actually prefer it to be the default behavior.

EDIT: Updated the PR to not add the hash anymore by default.